### PR TITLE
fix typo simplecov-formatter-shield/generators/shield_io => simplecov-formatter-shield/generators/shields_io

### DIFF
--- a/lib/simplecov-formatter-shield.rb
+++ b/lib/simplecov-formatter-shield.rb
@@ -24,7 +24,7 @@ module SimpleCov
             require 'simplecov-formatter-shield/generators/png'
             SimpleCov::Formatter::ShieldFormatter::Generators::Png
           when :shields_io
-            require 'simplecov-formatter-shield/generators/shield_io'
+            require 'simplecov-formatter-shield/generators/shields_io'
             SimpleCov::Formatter::ShieldFormatter::Generators::ShieldsIO
           else
             Logger.warn("Unknown generator #{generator}; pick one of: :svg, :png, :shields_io")


### PR DESCRIPTION
I encountered the following error.

```
Formatter SimpleCov::Formatter::ShieldFormatter failed with NameError: uninitialized constant SimpleCov::Formatter::ShieldFormatter::Generators
(/Users/****/vendor/bundle/ruby/2.3.0/gems/simplecov-formatter-shield-0.1.0/lib/simplecov-formatter-shield.rb:44:in `rescue in format')
```

I found out that this typo was the cause.